### PR TITLE
work on application button, log in page while logged in

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -22,10 +22,22 @@ app.constant('USER_ROLES', {
     student: 'student'
 });
 
-// upon a change in route, this checks if the user is logged in and is the correct user type to view the route
+/* Upon a change in route, this checks if the user is logged in and is the correct 
+ * user type to view the route. 
+ * Sets the css layout for the next page. 
+ * Reroutes a logged in user to home page if they attempt to access login page.
+ */
 app.run(function($rootScope, $location, UserAuthService, UserInfoService, USER_ROLES) {
     $rootScope.$on('$routeChangeStart', function(event, next) {
-       $rootScope.layout = next.layout;
+       // reroute logged in user from hitting login page
+       if (next.templateUrl === 'app/login/loginView.html' && UserAuthService.isAuthenticated()) {
+           if (UserInfoService.getUserType() === USER_ROLES.student) {
+                $location.path('/studentHome'); 
+           } else if (UserInfoService.getUserType() === USER_ROLES.faculty) {
+                $location.path('/facultyHome'); 
+           }    // rest TODO
+       }
+       // checks if a user is authorized to view a page
        var authRoles = next.permissions;
        if (!UserAuthService.isAuthorized(authRoles)) {
            event.preventDefault();
@@ -41,6 +53,10 @@ app.run(function($rootScope, $location, UserAuthService, UserInfoService, USER_R
                $location.path('/unauthorized');     
            }
        }
+   }); 
+   $rootScope.$on('$routeChangeSuccess', function(event, current, next) {
+        // this is here to grab the layout after path changes in routeChangeStart above
+        $rootScope.layout = current.layout;
    }); 
 });
 
@@ -73,7 +89,9 @@ app.config(function($locationProvider, $routeProvider, $httpProvider, USER_ROLES
         .when('/viewAccount', {
             templateUrl : 'app/account/accountView.html',
             controller : 'viewAccountController',
-            permissions : [USER_ROLES.all]
+            permissions : [USER_ROLES.student, USER_ROLES.faculty,
+                           USER_ROLES.administrative, USER_ROLES.human_resources,
+                           USER_ROLES.program_chair]
         })
         .when('/badrequest', {
             templateUrl : 'app/errors/404.html',

--- a/client/app/application/contactInfoView.html
+++ b/client/app/application/contactInfoView.html
@@ -11,7 +11,7 @@
             <input ng-model='addressOne' type="text" name="address1" placeholder="Address1*"><br>
             <input ng-model='addressTwo' type="text" name="address2" placeholder="Address2"><br>
             <input ng-model='city' type="text" name="city" placeholder="City"><br>
-            <input ng-model='state' type="text" name="field1" placeholder="State, Region, Provice*"><br>
+            <input ng-model='state' type="text" name="field1" placeholder="State, Region, Province*"><br>
             <input ng-model='zip' type="text" name="code" placeholder="Zip Code, Postal Code*"><br>
         </fieldset>
         <input type='button' ng-click='saveContact(false)' value="Save"></input>

--- a/client/app/header.html
+++ b/client/app/header.html
@@ -1,4 +1,4 @@
-<div ng-controller='logoutController'>
+<div ng-controller='headerController'>
     HEADER
     <a href='' ng-show='displayHome()' ng-click='goHome()'>Home</a>
     <a href='' ng-show='displayLogin()' ng-click='login()'>Login</a>

--- a/client/app/header.js
+++ b/client/app/header.js
@@ -6,7 +6,7 @@
 // setup module
 var header = angular.module('app.header', ['ngRoute']);
 
-header.controller('logoutController', function($scope, $location, UserInfoService, UserAuthService) {
+header.controller('headerController', function($scope, $location, UserInfoService, UserAuthService) {
 
     $scope.goHome = function() {
         if (UserInfoService.getUserType() === 'student') {
@@ -28,8 +28,7 @@ header.controller('logoutController', function($scope, $location, UserInfoServic
     }
     
     $scope.displayLogin = function() {
-        return !UserAuthService.isAuthenticated();
-
+        return $location.path() === '/unauthorized';
     }
        
     $scope.logout = function() {

--- a/client/app/users/student.js
+++ b/client/app/users/student.js
@@ -8,7 +8,19 @@
 // setup student module
 var student = angular.module('app.student', []);
 
-// student view page controllers - notice UserInfoService service injected
 student.controller('studentInfoController', function($scope, UserInfoService) {
     $scope.name = UserInfoService.getFullName();
+    
+    $scope.page = function() {
+        var last = UserInfoService.getLastSaved();
+        // im under the assumption that if the user has not started an application
+        // or has completed the application, the last saved page will be null
+        if (last !== 'null') {
+            $scope.link = 'Continue Application';
+            return '#!' + last;
+        } else {
+            $scope.link = 'Application';
+            return '#!/contactInfo'
+        }
+    }
 });

--- a/client/app/users/studentView.html
+++ b/client/app/users/studentView.html
@@ -2,5 +2,5 @@
     <li><a href="#!/viewAccount">Account</a><br>
     Student Home
     <li ng-model='name'>Name is {{name}}</li>
-    <li><a href="#!/contactInfo">Application</a><br>
+    <li><a ng-href={{page()}}>{{link}}</a><br>
 </div>  


### PR DESCRIPTION
1) added the login button in the header when the user gets a 401 error

2) removed login button from the header for any other page except above

3) now a logged in user can no longer reach the login/create account page by using the back button. this was a pain in the ass, as the path change ended up applying the login css to the home page. i added to the app.js  a route change success module that will apply the css layout property of a route after any path changes in route change start

4) as before when the user logs in, the last saved page is stored. so now, when the student goes to the home page, the application button shows 'continue application' if that 'lastPage' value is not null. otherwise, it just displays as 'Application'.

Some things I found:

        a) The last 3 pages of the application do not save the last saved page to send to the server

       b) The application pages need back buttons

       c) Might be a good idea at some point to add an indication that the page has saved